### PR TITLE
chore: always display idendity providers section

### DIFF
--- a/deploy/charts/distr/README.md
+++ b/deploy/charts/distr/README.md
@@ -47,7 +47,7 @@ helm upgrade --install --wait --namespace distr --create-namespace \
 | Repository                                  | Name       | Version    |
 | ------------------------------------------- | ---------- | ---------- |
 | https://charts.rustfs.com                   | rustfs     | 1.0.0-rc.3 |
-| oci://ghcr.io/grafana-community/helm-charts | loki       | 18.11.2    |
+| oci://ghcr.io/grafana-community/helm-charts | loki       | 18.11.3    |
 | oci://registry-1.docker.io/bitnamicharts    | postgresql | 18.8.13    |
 
 ## Values

--- a/frontend/ui/src/app/organization-settings/custom-oidc.component.html
+++ b/frontend/ui/src/app/organization-settings/custom-oidc.component.html
@@ -88,9 +88,15 @@
           </app-domain-field>
         }
 
-        @if (oidcProvidersEnabled() && configurable() && appDomain(); as domain) {
+        @if (oidcProvidersEnabled()) {
           <h4 class="text-base font-semibold text-gray-900 dark:text-white mt-8">Identity Providers</h4>
-          <ng-container [ngTemplateOutlet]="providerSection" [ngTemplateOutletContext]="{$implicit: domain}" />
+          @if (configurable() && appDomain(); as domain) {
+            <ng-container [ngTemplateOutlet]="providerSection" [ngTemplateOutletContext]="{$implicit: domain}" />
+          } @else if (!appDomain()) {
+            <p class="text-sm font-normal italic text-gray-500 dark:text-gray-400">
+              A custom domain is required to configure identity providers.
+            </p>
+          }
         }
       </section>
     }
@@ -135,9 +141,15 @@
         </app-domain-field>
       }
 
-      @if (oidcProvidersEnabled() && configurable() && customerPortalDomain(); as domain) {
+      @if (oidcProvidersEnabled()) {
         <h4 class="text-base font-semibold text-gray-900 dark:text-white mt-8">Identity Providers</h4>
-        <ng-container [ngTemplateOutlet]="providerSection" [ngTemplateOutletContext]="{$implicit: domain}" />
+        @if (configurable() && customerPortalDomain(); as domain) {
+          <ng-container [ngTemplateOutlet]="providerSection" [ngTemplateOutletContext]="{$implicit: domain}" />
+        } @else if (!customerPortalDomain()) {
+          <p class="text-sm font-normal italic text-gray-500 dark:text-gray-400">
+            A custom domain is required to configure identity providers.
+          </p>
+        }
       }
     </section>
 

--- a/frontend/ui/src/app/organization-settings/custom-oidc.component.html
+++ b/frontend/ui/src/app/organization-settings/custom-oidc.component.html
@@ -275,6 +275,10 @@
         <p class="text-xs font-normal text-yellow-700 dark:text-yellow-300">
           Identity providers only work on custom domains. Configure and verify one first.
         </p>
+      } @else if (!configurable()) {
+        <p class="text-xs font-normal text-yellow-700 dark:text-yellow-300">
+          An organization slug is required. Set one on the General tab first.
+        </p>
       }
     </div>
   </div>

--- a/frontend/ui/src/app/organization-settings/custom-oidc.component.html
+++ b/frontend/ui/src/app/organization-settings/custom-oidc.component.html
@@ -273,7 +273,8 @@
         </p>
       } @else if (!configurable()) {
         <p class="text-xs font-normal text-yellow-700 dark:text-yellow-300">
-          An organization slug is required. Set one on the General tab first.
+          An organization slug is required. Set one on the
+          <a routerLink="/settings/organization/general" class="font-semibold underline">General tab</a> first.
         </p>
       }
     </div>

--- a/frontend/ui/src/app/organization-settings/custom-oidc.component.html
+++ b/frontend/ui/src/app/organization-settings/custom-oidc.component.html
@@ -10,27 +10,24 @@
       </h2>
       <p class="text-sm font-normal text-gray-500 dark:text-gray-400">
         @if (customerScoped() && viewerIsCustomer()) {
-          Let your users sign in with their own identity provider via OIDC (OpenID Connect) instead of a Distr password.
-          A provider is offered on your own portal domain and nowhere else.
+          Let your users additionally sign in with their own identity provider via OIDC (OpenID Connect). A provider
+          only works on your own portal domain.
         } @else if (customerScoped()) {
-          Let this customer's users sign in with their own identity provider via OIDC (OpenID Connect) instead of a
-          Distr password. A provider is offered on the customer's own portal domain and nowhere else.
+          Let this customer's users additonally sign in with their own identity provider via OIDC (OpenID Connect). A
+          provider only works on the customer's own portal domain.
         } @else {
-          Let your team and your customers sign in with your own identity provider via OIDC (OpenID Connect) instead of
-          a Distr password. Every domain carries its own providers: the ones on your
-          <span class="lowercase">{{ appDomainLabel() }}</span> apply to your team, the ones on your customer portal
-          domain to all of your customers. Customers can also have providers of their own.
+          Let your team and your customers additionally sign in with your own identity provider via OIDC (OpenID
+          Connect). Each domain has its own providers. The ones on your
+          <span class="lowercase">{{ appDomainLabel() }}</span>
+          apply to your team, the ones on your customer portal domain to all of your customers. Customers can add their
+          own.
         }
-        A custom domain is required first: an identity provider is only offered on the domain it is attached to, and
-        nowhere else on Distr. A session it authenticates stays within this organization; it cannot change the account's
-        e-mail address, enroll in MFA or disconnect identity providers, while password-confirmed MFA actions remain
-        available.
+        A custom domain has to exist first.
       </p>
 
       @if (oidcProvidersEnabled() && !configurable()) {
         <p class="text-sm font-normal text-gray-500 dark:text-gray-400">
-          Set an organization slug on the General tab first &mdash; it is part of every provider's login and callback
-          URL.
+          Set an organization slug on the General tab first. It is part of every login and callback URL.
         </p>
       }
     </div>
@@ -99,12 +96,12 @@
       @if (!customerScoped()) {
         <h3 class="text-lg font-bold dark:text-white">Customer Portal</h3>
         <p class="text-sm font-normal text-gray-500 dark:text-gray-400">
-          One domain that all of your customers sign in on by default. A provider is only ever offered on the domain it
-          is attached to, so the customer portal domain below has to exist before you can configure one here; once it
-          does, the providers you add apply to every customer, including ones you create later.
+          One domain that all of your customers sign in on by default. Without it they keep using your
+          <span class="lowercase">{{ appDomainLabel() }}</span> or the default Distr host. Add it below first. Providers
+          on it apply to every customer, including the ones you create later.
         </p>
         <p class="text-sm font-normal text-gray-500 dark:text-gray-400">
-          Customers can override all of this with their own domain and providers, configured on their own
+          Customers can override this with their own domain and providers on their
           <a routerLink="/customers" class="font-semibold underline">settings page</a>.
         </p>
       }
@@ -126,7 +123,7 @@
           (recheck)="verifyDomain(customerPortalDomain()!)">
           @if (customerScoped()) {
             The domain this customer's users sign in on. Links in invitations, password resets and notification mails
-            use it.
+            use it. Without it they sign in on the vendor's domain.
           } @else {
             The domain all of your customers sign in on. Links in invitations, password resets and notification mails
             use it instead of your <span class="lowercase">{{ appDomainLabel() }}</span
@@ -147,9 +144,8 @@
       <section class="space-y-4">
         <h3 class="text-lg font-bold dark:text-white">Registry</h3>
         <p class="text-sm font-normal text-gray-500 dark:text-gray-400">
-          Only needed if you want a separate hostname for the artifact registry. Your
-          <span class="lowercase">{{ appDomainLabel() }}</span> already serves registry traffic under
-          <code class="font-mono">/v2/</code>, so a single domain is usually all you need.
+          You only need this if the artifact registry should have its own hostname. The hostname is part of the OCI
+          artifact name.
         </p>
         <app-domain-field
           fieldId="registryDomain"
@@ -327,8 +323,7 @@
               placeholder="https://login.microsoftonline.com/<tenant-id>/v2.0"
               class="distr-input" />
             <p class="text-xs font-normal text-gray-500 dark:text-gray-400">
-              The provider has to serve an OpenID configuration under this URL. It is verified and normalized when you
-              save.
+              The provider has to serve an OpenID configuration here. Distr checks and normalizes it when you save.
             </p>
           </div>
         </div>
@@ -376,7 +371,7 @@
           } @else {
             <p class="text-xs font-normal text-gray-500 dark:text-gray-400">
               Register this as a redirect URI with your provider. The slug follows the display name and is unique on
-              this domain; edit it with the pencil if you need a different one.
+              this domain. Edit it with the pencil if you need another one.
             </p>
           }
         </div>
@@ -448,14 +443,14 @@
                 Everyone your provider authenticates joins your own team, never a customer organization, up to your
                 billed user seats.
               }
-              Seats are never raised automatically: beyond them, sign-in fails until an administrator raises them. This
-              requires the allowed email domains below.
+              Seats are never added automatically, so sign-in fails until an administrator raises the limit. Name the
+              allowed email domains below.
             </p>
           </div>
         } @else {
           <p class="text-xs font-normal text-gray-500 dark:text-gray-400">
-            Accounts cannot be created automatically on the shared customer portal domain, because the provider does not
-            say which customer a new user belongs to. Invite them, or give the customer its own portal domain.
+            Distr cannot create accounts on the shared customer portal domain, because the provider does not say which
+            customer a new user belongs to. Invite them, or give the customer its own portal domain.
           </p>
         }
 
@@ -478,7 +473,7 @@
                 </p>
               } @else {
                 <p class="text-xs font-normal text-gray-500 dark:text-gray-400">
-                  Space separated. Accounts are only created for addresses in these domains.
+                  Space separated. Distr only creates accounts for addresses in these domains.
                 </p>
               }
             </div>
@@ -502,10 +497,10 @@
             </label>
           </div>
           <p class="text-xs font-normal text-gray-500 dark:text-gray-400">
-            Usually not recommended: the login page on this domain redirects here without asking, so everyone reaching
-            it ends up at the provider instead of the login form. Only one provider per domain can do this.
+            Usually not recommended. The login page on this domain then redirects here without asking, so nobody sees
+            the login form. Only one provider per domain can do this.
             <code class="font-mono">/login?manual=1</code> still shows the form, which is how anyone with a password
-            gets in when the provider is unavailable.
+            gets in while the provider is unavailable.
           </p>
         </div>
 

--- a/frontend/ui/src/app/organization-settings/custom-oidc.component.html
+++ b/frontend/ui/src/app/organization-settings/custom-oidc.component.html
@@ -25,7 +25,7 @@
         A custom domain has to exist first.
       </p>
 
-      @if (oidcProvidersEnabled() && !configurable()) {
+      @if (oidcProvidersEnabled() && viewerIsVendor() && !configurable()) {
         <p class="text-sm font-normal text-gray-500 dark:text-gray-400">
           Set an organization slug on the General tab first. It is part of every login and callback URL.
         </p>
@@ -271,7 +271,7 @@
         <p class="text-xs font-normal text-yellow-700 dark:text-yellow-300">
           Identity providers only work on custom domains. Configure and verify one first.
         </p>
-      } @else if (!configurable()) {
+      } @else if (viewerIsVendor() && !configurable()) {
         <p class="text-xs font-normal text-yellow-700 dark:text-yellow-300">
           An organization slug is required. Set one on the
           <a routerLink="/settings/organization/general" class="font-semibold underline">General tab</a> first.

--- a/frontend/ui/src/app/organization-settings/custom-oidc.component.html
+++ b/frontend/ui/src/app/organization-settings/custom-oidc.component.html
@@ -90,13 +90,7 @@
 
         @if (oidcProvidersEnabled()) {
           <h4 class="text-base font-semibold text-gray-900 dark:text-white mt-8">Identity Providers</h4>
-          @if (configurable() && appDomain(); as domain) {
-            <ng-container [ngTemplateOutlet]="providerSection" [ngTemplateOutletContext]="{$implicit: domain}" />
-          } @else if (!appDomain()) {
-            <p class="text-sm font-normal italic text-gray-500 dark:text-gray-400">
-              A custom domain is required to configure identity providers.
-            </p>
-          }
+          <ng-container [ngTemplateOutlet]="providerSection" [ngTemplateOutletContext]="{$implicit: appDomain()}" />
         }
       </section>
     }
@@ -143,13 +137,9 @@
 
       @if (oidcProvidersEnabled()) {
         <h4 class="text-base font-semibold text-gray-900 dark:text-white mt-8">Identity Providers</h4>
-        @if (configurable() && customerPortalDomain(); as domain) {
-          <ng-container [ngTemplateOutlet]="providerSection" [ngTemplateOutletContext]="{$implicit: domain}" />
-        } @else if (!customerPortalDomain()) {
-          <p class="text-sm font-normal italic text-gray-500 dark:text-gray-400">
-            A custom domain is required to configure identity providers.
-          </p>
-        }
+        <ng-container
+          [ngTemplateOutlet]="providerSection"
+          [ngTemplateOutletContext]="{$implicit: customerPortalDomain()}" />
       }
     </section>
 
@@ -224,7 +214,6 @@
                     </span>
                   }
                 </div>
-                <code class="font-mono text-xs text-gray-500 dark:text-gray-400">{{ configuration.slug }}</code>
               </td>
               <td class="px-4 py-3">
                 <div class="flex items-center gap-2">
@@ -241,13 +230,14 @@
                   type="button"
                   (click)="test(configuration)"
                   class="py-2 px-3 flex items-center text-sm font-medium text-center distr-btn-secondary">
+                  <fa-icon [icon]="faPlug" class="mr-2 text-gray-500 dark:text-gray-400" />
                   Test
                 </button>
                 <button
                   type="button"
                   (click)="showDialog(domain, configuration)"
                   class="py-2 px-3 flex items-center text-sm font-medium text-center distr-btn-secondary">
-                  <fa-icon [icon]="faPen" class="h-4 w-4 mr-2 -ml-0.5 text-gray-500 dark:text-gray-400" />
+                  <fa-icon [icon]="faPen" class="mr-2 text-gray-500 dark:text-gray-400" />
                   Edit
                 </button>
                 <button
@@ -272,13 +262,21 @@
       </table>
     </div>
 
-    <button
-      type="button"
-      (click)="showDialog(domain)"
-      class="py-2 px-4 flex items-center text-sm font-medium text-center distr-btn-secondary">
-      <fa-icon [icon]="faPlus" class="h-4 w-4 mr-2 -ml-0.5 text-gray-500 dark:text-gray-400" />
-      Add identity provider
-    </button>
+    <div class="space-y-2">
+      <button
+        type="button"
+        [disabled]="!domain || !configurable()"
+        (click)="showDialog(domain)"
+        class="py-2 px-4 flex items-center text-sm font-medium text-center distr-btn-secondary disabled:opacity-60 disabled:cursor-not-allowed">
+        <fa-icon [icon]="faPlus" class="mr-2 text-gray-500 dark:text-gray-400" />
+        Add identity provider
+      </button>
+      @if (!domain) {
+        <p class="text-xs font-normal text-yellow-700 dark:text-yellow-300">
+          Identity providers only work on custom domains. Configure and verify one first.
+        </p>
+      }
+    </div>
   </div>
 </ng-template>
 

--- a/frontend/ui/src/app/organization-settings/custom-oidc.component.ts
+++ b/frontend/ui/src/app/organization-settings/custom-oidc.component.ts
@@ -60,33 +60,23 @@ export class CustomOidcComponent {
   private readonly remoteEnv = toSignal(from(getRemoteEnvironment()));
   protected readonly cnameTarget = computed(() => this.remoteEnv()?.customDomainTarget);
 
-  // Separate, because domains and the identity providers on them change independently: only removing
-  // a domain takes its providers with it.
   private readonly domainsRefresh$ = new BehaviorSubject<void>(undefined);
   private readonly configurationsRefresh$ = new BehaviorSubject<void>(undefined);
 
-  // Set on the customer-scoped page, where only the customer's own portal domain is managed.
   public readonly customerOrganizationId = input<string>();
 
   protected readonly customerScoped = computed(() => !!this.customerOrganizationId());
-  // A customer-scoped page is reached both by the customer's own admins and by a vendor managing that
-  // customer on their behalf; the copy addresses "your users" only for the former.
   protected readonly viewerIsCustomer = computed(() => this.auth.isCustomer());
+  protected readonly viewerIsVendor = computed(() => this.auth.isVendor());
   protected readonly partnerManagementEnabled = computed(() => this.featureFlags.isPartnerManagementEnabled());
   protected readonly appDomainLabel = computed(() =>
     this.partnerManagementEnabled() ? 'Vendor & Partner Portal domain' : 'Vendor Portal domain'
   );
-  // On a customer's own settings page the portal domain is the reason the page exists, so it is not
-  // hidden behind a checkbox there the way the vendor's optional domains are.
   protected readonly customerPortalCheckboxLabel = computed(() =>
     this.customerScoped() ? undefined : 'Use a customer portal domain'
   );
-  // Self-hosted instances that never configured a CNAME target have nothing to serve a custom domain
-  // with, so the domain fields (not the identity providers of ones already configured) stay hidden.
   protected readonly customDomainsConfigured = computed(() => !!this.cnameTarget());
 
-  // The tab and its route guard open on either feature (see organization-settings.component.ts /
-  // app-logged-in.routes.ts), so an org with only custom_domains must not end up on a blank page.
   protected readonly domainsEnabled = computed(() => this.featureFlags.isCustomDomainsEnabled());
   protected readonly oidcProvidersEnabled = computed(() => this.featureFlags.isCustomOidcProvidersEnabled());
 
@@ -113,9 +103,6 @@ export class CustomOidcComponent {
       this.auth.hasRole('admin')
   );
 
-  // The server returns every provider within the caller's scope, a vendor's own and each customer's
-  // alike, which is why configurationsFor narrows to the one domain being rendered. Requested only
-  // with the feature enabled, because the endpoint 403s without it.
   private readonly response = toSignal(
     combineLatest([this.featureFlags.isCustomOidcProvidersEnabled$, this.configurationsRefresh$]).pipe(
       switchMap(([enabled]) =>
@@ -138,8 +125,6 @@ export class CustomOidcComponent {
     ),
     {initialValue: [] as CustomDomain[]}
   );
-  // Writable so that a check can be applied to the domain it was run for, which is cheaper than
-  // fetching the whole list back for a state the check itself returns. Resets on every fetch.
   private readonly domains = linkedSignal(() => this.fetchedDomains());
   protected readonly scopedDomains = computed(() =>
     this.domains().filter((d) => (d.customerOrganizationId ?? undefined) === this.customerOrganizationId())
@@ -152,9 +137,6 @@ export class CustomOidcComponent {
     this.scopedDomains().find((domain) => domain.domainType === 'customer_portal')
   );
 
-  // The domains a check was asked for and has not come back from. A domain carries the outcome of
-  // its last check, kept up to date by a background job, so the page renders a status without ever
-  // looking up DNS itself.
   protected readonly checkingDomainIds = signal<ReadonlySet<string>>(new Set());
 
   constructor() {
@@ -173,8 +155,6 @@ export class CustomOidcComponent {
       if (verification.inconclusive) {
         this.toast.error('The DNS lookup could not be completed, please try again');
       } else if (verification.verified !== domain.verified) {
-        // Only then can the organization's effective registry host have changed, in either direction:
-        // a domain becoming usable, or one that was usable falling back to the default host.
         this.contextService.reload();
       }
     } catch (e) {
@@ -216,7 +196,6 @@ export class CustomOidcComponent {
         this.customDomainsService.create([{domain: value, domainType}], this.customerOrganizationId())
       );
       this.domainsRefresh$.next();
-      // The effective registry host of the organization may have changed with the new domain.
       this.contextService.reload();
       this.toast.success('Custom domain saved');
     } catch (e) {
@@ -244,7 +223,6 @@ export class CustomOidcComponent {
     try {
       await firstValueFrom(this.customDomainsService.delete(domain.id));
       this.domainsRefresh$.next();
-      // The domain took its identity providers with it.
       this.configurationsRefresh$.next();
       this.contextService.reload();
       this.toast.success('Custom domain removed');
@@ -267,8 +245,6 @@ export class CustomOidcComponent {
     return domain ? this.configurations().filter((configuration) => configuration.customDomainId === domain.id) : [];
   }
 
-  // Each host carries its own provider set, so a provider belongs to the domain and not to the
-  // organization.
   private readonly activeDomain = signal<CustomDomain | undefined>(undefined);
   protected readonly editing = signal<CustomOidcConfiguration | undefined>(undefined);
   protected readonly saving = signal(false);
@@ -314,8 +290,6 @@ export class CustomOidcComponent {
     return prefix && slug ? `${prefix}${slug}/callback` : undefined;
   });
 
-  // An existing provider counts as hand-edited: its slug is part of the redirect URI registered with the
-  // identity provider, so renaming the provider must not silently invalidate it.
   private readonly slugEdited = signal(false);
   protected readonly editingSlug = signal(false);
 
@@ -338,7 +312,6 @@ export class CustomOidcComponent {
         clientId: configuration.clientId,
         clientSecret: '',
         spInitiated: configuration.spInitiated,
-        // The checkbox is not rendered when provisioning is unavailable, so a stored true could not be cleared.
         createUnknownUsers: configuration.createUnknownUsers && this.provisioningAvailable(),
         defaultUserRole: configuration.defaultUserRole,
         allowedEmailDomains: configuration.allowedEmailDomains.join(' '),
@@ -356,7 +329,6 @@ export class CustomOidcComponent {
     this.dialogRef?.close();
   }
 
-  // Automatic provisioning has no customer to provision into on the vendor's shared portal domain.
   protected readonly provisioningAvailable = computed(() => {
     const domain = this.activeDomain();
     return !!domain && (domain.domainType !== 'customer_portal' || !!domain.customerOrganizationId);
@@ -372,8 +344,6 @@ export class CustomOidcComponent {
     const existing = this.editing();
     const request = {
       customDomainId,
-      // Only meaningful on create; the server ignores it on update, since the existing row already
-      // pins the scope.
       customerOrganizationId: this.customerOrganizationId(),
       name: value.name,
       slug: value.slug,
@@ -381,8 +351,6 @@ export class CustomOidcComponent {
       issuer: value.issuer,
       clientId: value.clientId,
       clientSecret: value.clientSecret || undefined,
-      // Not offered in the dialog: the defaults work with every provider, and an organization that needs
-      // something else sets it through the API, which this must not overwrite.
       scopes: existing?.scopes ?? DEFAULT_SCOPES,
       pkceEnabled: existing?.pkceEnabled,
       spInitiated: value.spInitiated,
@@ -432,7 +400,6 @@ export class CustomOidcComponent {
       );
       this.configurationsRefresh$.next();
     } catch (e) {
-      // the browser has already flipped the checkbox, and re-rendering the row does not undo that
       toggle.checked = configuration.enabled;
       const msg = getFormDisplayedError(e);
       if (msg) {

--- a/frontend/ui/src/app/organization-settings/custom-oidc.component.ts
+++ b/frontend/ui/src/app/organization-settings/custom-oidc.component.ts
@@ -4,7 +4,7 @@ import {takeUntilDestroyed, toSignal} from '@angular/core/rxjs-interop';
 import {AbstractControl, FormBuilder, ReactiveFormsModule, ValidationErrors, Validators} from '@angular/forms';
 import {RouterLink} from '@angular/router';
 import {FaIconComponent} from '@fortawesome/angular-fontawesome';
-import {faPen, faPlus, faTrash, faXmark} from '@fortawesome/free-solid-svg-icons';
+import {faPen, faPlug, faPlus, faTrash, faXmark} from '@fortawesome/free-solid-svg-icons';
 import {BehaviorSubject, combineLatest, firstValueFrom, from, map, of, switchMap} from 'rxjs';
 import {getRemoteEnvironment} from '../../env/remote';
 import {getFormDisplayedError} from '../../util/errors';
@@ -43,6 +43,7 @@ const DEFAULT_SCOPES = ['openid', 'profile', 'email'];
 export class CustomOidcComponent {
   protected readonly faPlus = faPlus;
   protected readonly faPen = faPen;
+  protected readonly faPlug = faPlug;
   protected readonly faTrash = faTrash;
   protected readonly faXmark = faXmark;
 
@@ -262,8 +263,8 @@ export class CustomOidcComponent {
 
   protected readonly configurable = computed(() => !!this.organizationSlug());
 
-  protected configurationsFor(domain: CustomDomain): CustomOidcConfiguration[] {
-    return this.configurations().filter((configuration) => configuration.customDomainId === domain.id);
+  protected configurationsFor(domain: CustomDomain | undefined): CustomOidcConfiguration[] {
+    return domain ? this.configurations().filter((configuration) => configuration.customDomainId === domain.id) : [];
   }
 
   // Each host carries its own provider set, so a provider belongs to the domain and not to the

--- a/frontend/ui/src/app/organization-settings/domain-field.component.ts
+++ b/frontend/ui/src/app/organization-settings/domain-field.component.ts
@@ -9,7 +9,7 @@ import {AutotrimDirective} from '../directives/autotrim.directive';
 import {CustomDomain} from '../types/custom-domain';
 
 // A single CNAME-configurable domain field: shows the existing domain with a remove button once
-// configured, or a validated hostname input beforehand. Purely presentational — the domain list and
+// configured, or a validated hostname input beforehand. Purely presentational. The domain list and
 // the actual create/delete calls belong to the parent, which knows the domain type and scope.
 @Component({
   selector: 'app-domain-field',

--- a/frontend/ui/src/app/organization-settings/general-settings.component.html
+++ b/frontend/ui/src/app/organization-settings/general-settings.component.html
@@ -46,9 +46,8 @@
           placeholder="slug" />
         <p class="mt-1 mb-3 text-xs font-normal text-gray-500 dark:text-gray-400">
           The slug is part of the URLs that belong to your organization: your artifact registry repositories and the
-          login and callback URL of every identity provider you configure. It must start with a lower case letter or
-          digit and consist only of lowercase letters, digits, as well as the following special characters: “.”, “_”,
-          “__”, “-”.
+          login and callback URL of every identity provider you configure. It has to start with a lowercase letter or
+          digit and may otherwise contain lowercase letters, digits and the characters ".", "_", "__" and "-".
         </p>
         @if (form.controls.slug.invalid && form.controls.slug.touched) {
           <p class="mt-1 text-sm text-red-600 dark:text-red-500">Slug must be url safe.</p>
@@ -82,8 +81,8 @@
           Enable Pre- and Post-Connect Scripts (Pre-Flight Checks)
         </label>
         <p class="mt-1 mb-3 text-xs font-normal text-gray-500 dark:text-gray-400">
-          When enabled, Docker agent install commands will use a shell script that wraps docker compose, allowing pre-
-          and post-connect scripts to run during agent setup.
+          When enabled, Docker agent install commands use a shell script that wraps docker compose, so that pre- and
+          post-connect scripts can run during agent setup.
         </p>
       </div>
     </div>

--- a/frontend/ui/src/app/types/custom-oidc.ts
+++ b/frontend/ui/src/app/types/custom-oidc.ts
@@ -26,7 +26,6 @@ export interface CustomOidcConfigurationsResponse {
 
 export interface CustomOidcConfigurationRequest {
   customDomainId: string;
-  // Targets a customer's own provider instead of the caller's own; only meaningful on create.
   customerOrganizationId?: string;
   name: string;
   slug: string;


### PR DESCRIPTION
I deliberately not displaying the whole table but rather only the subheading on the condition that the custom identity feature is present.