### PR TITLE
feat(website): notify IndexNow about changed pages and emit sitemap lastmod

### DIFF
--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -40,6 +40,11 @@ jobs:
             website
             CHANGELOG.md
           sparse-checkout-cone-mode: false
+          # Starlight's lastUpdated reads each page's git history. At depth 1
+          # every docs page is stamped with the deploy commit instead, which
+          # both misinforms readers and makes IndexNow see all of them change on
+          # every deploy.
+          fetch-depth: 0
       - name: Restore LFS cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -82,6 +87,19 @@ jobs:
         with:
           aws-region: eu-central-1
           role-to-assume: arn:aws:iam::639130800065:role/github-actions-distr.sh
+      - name: Write IndexNow key file
+        if: github.ref == 'refs/heads/main'
+        env:
+          INDEXNOW_KEY: ${{ secrets.INDEXNOW_KEY }}
+        run: |
+          if [ -z "$INDEXNOW_KEY" ]; then
+            echo "INDEXNOW_KEY is not set, skipping the key file."
+            exit 0
+          fi
+          printf '%s' "$INDEXNOW_KEY" > "dist/$INDEXNOW_KEY.txt"
+      - name: Detect changed pages
+        if: github.ref == 'refs/heads/main'
+        run: node scripts/indexnow.mjs prepare
       - name: Deploy hashed assets
         if: github.ref == 'refs/heads/main'
         run: >-
@@ -100,3 +118,8 @@ jobs:
           aws cloudfront create-invalidation
           --distribution-id E1PG5UM7ZE1H97
           --invalidation-batch "Paths={Quantity='1' ,Items=['/*']},CallerReference=WEBSITE_$GITHUB_RUN_ID"
+      - name: Submit changed pages to IndexNow
+        if: github.ref == 'refs/heads/main'
+        env:
+          INDEXNOW_KEY: ${{ secrets.INDEXNOW_KEY }}
+        run: node scripts/indexnow.mjs submit

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -2,6 +2,8 @@
 dist/
 # generated types
 .astro/
+# IndexNow deploy state (scripts/indexnow.mjs)
+.indexnow/
 
 # dependencies
 node_modules/

--- a/website/scripts/indexnow.md
+++ b/website/scripts/indexnow.md
@@ -1,0 +1,104 @@
+# IndexNow submissions and sitemap lastmod
+
+`scripts/indexnow.mjs` notifies IndexNow about pages that changed in a deploy,
+and fills in the sitemap's `lastmod` values from the same state. IndexNow reaches
+Bing, Yandex, Seznam, Naver, Yep, Internet Archive and Amazonbot. Google does not
+participate, so this speeds up Bing pickup — and with it DuckDuckGo, Copilot and
+ChatGPT search — rather than affecting Google rankings.
+
+The protocol wants only genuinely changed URLs; resubmitting unchanged ones
+wastes crawl quota and risks a 429. The script therefore hashes every page in
+`dist/` and compares those hashes against the previous deploy, so it never has to
+map a source file back to a URL or read git history.
+
+## How a deploy uses it
+
+`.github/workflows/website.yaml` runs two commands on `main`, both after the AWS
+credentials step so the manifest is reachable:
+
+1. `node scripts/indexnow.mjs prepare`, before the S3 sync. It reads the URLs
+   from `dist/sitemap-*.xml`, hashes each page, diffs against the manifest,
+   writes `lastmod` into the sitemap files and records the changed URLs in
+   `.indexnow/pending.json`.
+2. `node scripts/indexnow.mjs submit`, after the sync and the CloudFront
+   invalidation, so crawlers arriving immediately see the new content. It posts
+   the recorded URLs to `https://api.indexnow.org/indexnow` and stores the new
+   manifest.
+
+Candidate URLs come from the built sitemap, which means the `noindex` exclusions
+and the redirect map in `astro.config.mjs` are respected without repeating them
+here.
+
+## Manifest
+
+`s3://distr.sh/.indexnow/manifest.json`, uploaded without `--acl` so it stays
+private while the pages around it are `public-read`:
+
+```json
+{
+  "version": 1,
+  "urls": {
+    "https://distr.sh/about/": {
+      "hash": "9f86d081884c7d65...",
+      "lastmod": "2026-09-02T10:14:07Z"
+    }
+  }
+}
+```
+
+`lastmod` stays `null` until the script actually observes that page change. Bing
+disregards `lastmod` values that all sit on the same date, which is exactly what
+backfilling the first deploy would produce, and IndexNow asks for changes made
+after adoption only. So the first run records hashes, submits nothing and emits
+no dates; pages pick up a `lastmod` as they change.
+
+Because the previous deploy's state lives in S3, `lastmod` is injected in CI
+rather than by `@astrojs/sitemap`. A local `pnpm build` produces a sitemap
+without it.
+
+Three consequences worth knowing:
+
+- Editing a shared component such as the footer really does change every page, so
+  all of them are submitted. That is accurate and fits in a single request.
+- A failed submission leaves the manifest untouched, so the next deploy retries
+  the same URLs instead of losing them.
+- The homepage can be reported as changed when it was not.
+  `src/assets/index.ts` imports both
+  `screenshots/distr/distr-customer-portal-artifacts.webp` and its byte-identical
+  twin `…-artifacts-light.webp`, so Astro emits one file for the two and which of
+  the two names wins shifts with build ordering. Dropping the duplicate would
+  settle it, but that belongs to the screenshot pipeline rather than here.
+
+## Running it locally
+
+`--dry-run` keeps everything on disk: the manifest is read from and written to
+`website/.indexnow/manifest.json`, and nothing is submitted.
+
+```sh
+pnpm build
+node scripts/indexnow.mjs prepare --dry-run
+```
+
+Running it twice with a rebuild in between is the way to check that the hash
+normalization still ignores Astro's fingerprinted asset names — the second run
+has to report zero changed pages.
+
+## One-time setup
+
+1. Generate a key with `openssl rand -hex 16`. IndexNow allows `a-z`, `A-Z`,
+   `0-9` and `-`, between 8 and 128 characters.
+2. Add it as the `INDEXNOW_KEY` repository secret. The deploy writes it to
+   `dist/<key>.txt`, so the key is served from `https://distr.sh/<key>.txt`
+   without its name appearing in this public repository. Until the secret exists,
+   the deploy still maintains the manifest and the sitemap `lastmod` values and
+   only skips the submission.
+3. Claim distr.sh in [Bing Webmaster Tools](https://www.bing.com/webmasters),
+   which can import the site from Google Search Console. Neither IndexNow nor any
+   Bing API exposes submission history, so its IndexNow report is the only place
+   to confirm that submissions land.
+4. Check that the `github-actions-distr.sh` role may `GetObject` and `PutObject`
+   on `distr.sh/.indexnow/*`. A read failure is reported and treated as a first
+   run, but a write failure fails the step.
+
+Rotating the key leaves the old key file in the bucket, because neither sync uses
+`--delete`. Remove it by hand.

--- a/website/scripts/indexnow.mjs
+++ b/website/scripts/indexnow.mjs
@@ -1,0 +1,346 @@
+#!/usr/bin/env node
+import {parse} from 'node-html-parser';
+import {execFile} from 'node:child_process';
+import {createHash} from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import {fileURLToPath} from 'node:url';
+import {promisify} from 'node:util';
+
+const run = promisify(execFile);
+
+const websiteRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+);
+const distDir = path.join(websiteRoot, 'dist');
+const stateDir = path.join(websiteRoot, '.indexnow');
+const pendingFile = path.join(stateDir, 'pending.json');
+const manifestFile = path.join(stateDir, 'manifest.json');
+const manifestUri = 's3://distr.sh/.indexnow/manifest.json';
+const submissionEndpoint = 'https://api.indexnow.org/indexnow';
+const host = 'distr.sh';
+const manifestVersion = 1;
+// IndexNow rejects requests carrying more than 10000 URLs.
+const maxUrlsPerRequest = 10000;
+
+const sitemapFilePattern = /^sitemap-\d+\.xml$/;
+const sitemapIndexFile = 'sitemap-index.xml';
+const locationPattern = /<loc>([^<]*)<\/loc>/g;
+// Consuming a <lastmod> that is already there keeps a rerun over the same
+// dist from stacking a second one onto every entry.
+const locationEntryPattern =
+  /<loc>([^<]*)<\/loc>(?:<lastmod>[^<]*<\/lastmod>)?/g;
+
+// Astro fingerprints emitted assets, so a dependency bump changes every page's
+// markup without changing a word of its content. Both forms are collapsed
+// before hashing: '_astro/print.ehPL0gv-.css' keeps its name and extension,
+// while a font file is named after its hash alone and keeps nothing.
+const hashedFontReference = /_astro\/fonts\/[A-Za-z0-9_-]+(\.[A-Za-z0-9]+)/g;
+const hashedAssetReference =
+  /(_astro\/[A-Za-z0-9._/-]*?)\.[A-Za-z0-9_-]{8,}(\.[A-Za-z0-9]+)(?![A-Za-z0-9._-])/g;
+
+function printHelp() {
+  console.log(`Usage: node scripts/indexnow.mjs <prepare|submit> [--dry-run]
+
+prepare  Hash every page the sitemap lists, diff it against the manifest of the
+         previous deploy, write the resulting lastmod values into the sitemap
+         and record the changed URLs for "submit". Run after "pnpm build" and
+         before the S3 sync.
+submit   Send the recorded URLs to IndexNow and persist the new manifest. Run
+         after the S3 sync and the CloudFront invalidation.
+
+--dry-run  Keep everything local: read and write the manifest in
+           website/.indexnow instead of S3, and submit nothing.
+
+See scripts/indexnow.md.`);
+}
+
+function decodeXmlText(value) {
+  return value
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+    .replaceAll('&quot;', '"')
+    .replaceAll('&apos;', "'")
+    .replaceAll('&amp;', '&');
+}
+
+function distFileForUrl(url) {
+  const relative = new URL(url).pathname.replace(/^\/+|\/+$/g, '');
+  return relative.endsWith('.html')
+    ? path.join(distDir, relative)
+    : path.join(distDir, relative, 'index.html');
+}
+
+function contentHash(html) {
+  const document = parse(html);
+  for (const element of document.querySelectorAll('style')) {
+    element.remove();
+  }
+  for (const element of document.querySelectorAll('script')) {
+    // Glossary and CRA pages carry a JSON-LD 'dateModified', which is content.
+    if (element.getAttribute('type') !== 'application/ld+json') {
+      element.remove();
+    }
+  }
+  const normalized = document
+    .toString()
+    .replaceAll(hashedFontReference, '_astro/fonts/font$1')
+    .replaceAll(hashedAssetReference, '$1$2');
+  return createHash('sha256').update(normalized).digest('hex');
+}
+
+// The sitemap schema fixes the order of a <url>'s children, so <lastmod> has to
+// follow <loc> rather than being appended.
+function withLastmod(xml, lastmodFor) {
+  return xml.replaceAll(locationEntryPattern, (_match, location) => {
+    const lastmod = lastmodFor(decodeXmlText(location));
+    const entry = `<loc>${location}</loc>`;
+    return lastmod ? `${entry}<lastmod>${lastmod}</lastmod>` : entry;
+  });
+}
+
+async function readSitemap() {
+  const names = (await fs.readdir(distDir).catch(() => [])).filter(name =>
+    sitemapFilePattern.test(name),
+  );
+  if (names.length === 0) {
+    throw new Error(`No sitemap in ${distDir}. Run "pnpm build" first.`);
+  }
+  const urls = new Set();
+  for (const name of names.sort()) {
+    const xml = await fs.readFile(path.join(distDir, name), 'utf8');
+    for (const [, location] of xml.matchAll(locationPattern)) {
+      urls.add(decodeXmlText(location));
+    }
+  }
+  return {names, urls: [...urls]};
+}
+
+async function hashPages(urls) {
+  const hashes = new Map();
+  const missing = [];
+  for (const url of urls) {
+    const file = distFileForUrl(url);
+    const html = await fs.readFile(file, 'utf8').catch(() => undefined);
+    if (html === undefined) {
+      missing.push(`${url} (expected ${path.relative(websiteRoot, file)})`);
+      continue;
+    }
+    hashes.set(url, contentHash(html));
+  }
+  if (missing.length > 0) {
+    throw new Error(
+      `The sitemap lists ${missing.length} URL(s) without a built page:\n  ${missing.join('\n  ')}`,
+    );
+  }
+  return hashes;
+}
+
+function parseManifest(contents, source) {
+  const manifest = JSON.parse(contents);
+  if (manifest.version !== manifestVersion) {
+    throw new Error(
+      `Manifest at ${source} has version ${manifest.version}, expected ${manifestVersion}.`,
+    );
+  }
+  return manifest;
+}
+
+async function readManifest(dryRun) {
+  if (dryRun) {
+    const contents = await fs.readFile(manifestFile, 'utf8').catch(() => '');
+    if (contents === '') {
+      console.log(
+        `No manifest at ${path.relative(websiteRoot, manifestFile)}.`,
+      );
+      return undefined;
+    }
+    return parseManifest(contents, manifestFile);
+  }
+  let stdout;
+  try {
+    ({stdout} = await run('aws', ['s3', 'cp', manifestUri, '-']));
+  } catch (error) {
+    // S3 answers a missing key with 403 rather than 404 when the caller has no
+    // ListBucket permission, so a failed read cannot be told apart from a first
+    // run. Reading it as a first run is the safe choice because it submits
+    // nothing; a real permission problem surfaces when "submit" writes back.
+    console.log(
+      `No manifest read from ${manifestUri}, treating this as a first run.`,
+    );
+    console.log(`  ${String(error.stderr ?? error.message).trim()}`);
+    return undefined;
+  }
+  return parseManifest(stdout, manifestUri);
+}
+
+async function writeManifest(manifest, dryRun) {
+  await fs.mkdir(stateDir, {recursive: true});
+  await fs.writeFile(manifestFile, `${JSON.stringify(manifest, null, 2)}\n`);
+  const count = Object.keys(manifest.urls).length;
+  if (dryRun) {
+    console.log(
+      `Wrote ${count} entries to ${path.relative(websiteRoot, manifestFile)}.`,
+    );
+    return;
+  }
+  // No --acl, so the manifest stays private: the deploy grants public-read to
+  // the site's own objects only.
+  await run('aws', [
+    's3',
+    'cp',
+    manifestFile,
+    manifestUri,
+    '--content-type',
+    'application/json',
+  ]);
+  console.log(`Wrote ${count} entries to ${manifestUri}.`);
+}
+
+async function prepare(dryRun) {
+  const now = new Date().toISOString().replace(/\.\d+Z$/, 'Z');
+  const sitemap = await readSitemap();
+  const hashes = await hashPages(sitemap.urls);
+  const previous = await readManifest(dryRun);
+  const isFirstRun = previous === undefined;
+  const previousUrls = previous?.urls ?? {};
+
+  const changed = [];
+  const urls = {};
+  for (const [url, hash] of hashes) {
+    const before = previousUrls[url];
+    if (before?.hash === hash) {
+      urls[url] = {hash, lastmod: before.lastmod};
+      continue;
+    }
+    // A first run has nothing to compare against, and IndexNow asks for changes
+    // made after adoption only. Leaving lastmod unset until a change is really
+    // observed also keeps Bing from seeing every page dated the same day, which
+    // it treats as a reason to disregard the dates.
+    urls[url] = {hash, lastmod: isFirstRun ? null : now};
+    if (!isFirstRun) {
+      changed.push(url);
+    }
+  }
+  // Engines drop a page once they see it gone, so removals are worth sending.
+  const removed = Object.keys(previousUrls).filter(url => !hashes.has(url));
+
+  const lastmodByUrl = new Map(
+    Object.entries(urls)
+      .filter(([, entry]) => entry.lastmod !== null)
+      .map(([url, entry]) => [url, entry.lastmod]),
+  );
+  for (const name of sitemap.names) {
+    const file = path.join(distDir, name);
+    const xml = await fs.readFile(file, 'utf8');
+    await fs.writeFile(
+      file,
+      withLastmod(xml, url => lastmodByUrl.get(url)),
+    );
+  }
+  const newest = [...lastmodByUrl.values()].sort().at(-1);
+  const indexFile = path.join(distDir, sitemapIndexFile);
+  const indexXml = await fs.readFile(indexFile, 'utf8').catch(() => undefined);
+  if (indexXml !== undefined) {
+    await fs.writeFile(
+      indexFile,
+      withLastmod(indexXml, () => newest),
+    );
+  }
+
+  const manifest = {version: manifestVersion, urls};
+  await fs.mkdir(stateDir, {recursive: true});
+  await fs.writeFile(
+    pendingFile,
+    `${JSON.stringify({urls: [...changed, ...removed], manifest}, null, 2)}\n`,
+  );
+
+  console.log(
+    `${hashes.size} indexable pages, ${changed.length} changed, ${removed.length} removed, ${lastmodByUrl.size} with lastmod.`,
+  );
+  if (isFirstRun) {
+    console.log('First run: recording the manifest without submitting.');
+  }
+  if (dryRun) {
+    await writeManifest(manifest, dryRun);
+  }
+}
+
+async function submit(dryRun) {
+  const contents = await fs.readFile(pendingFile, 'utf8').catch(() => '');
+  if (contents === '') {
+    throw new Error(
+      `No ${path.relative(websiteRoot, pendingFile)}. Run "prepare" first.`,
+    );
+  }
+  const pending = JSON.parse(contents);
+  const key = process.env.INDEXNOW_KEY;
+
+  if (pending.urls.length === 0) {
+    console.log('Nothing to submit.');
+  } else if (!key) {
+    // The manifest is still recorded, so the sitemap keeps getting lastmod
+    // values even before the key exists.
+    console.log(
+      `INDEXNOW_KEY is not set, not submitting ${pending.urls.length} URL(s).`,
+    );
+  } else if (dryRun) {
+    console.log(`Dry run, would submit:\n  ${pending.urls.join('\n  ')}`);
+  } else {
+    for (let i = 0; i < pending.urls.length; i += maxUrlsPerRequest) {
+      const urlList = pending.urls.slice(i, i + maxUrlsPerRequest);
+      const response = await fetch(submissionEndpoint, {
+        method: 'POST',
+        headers: {'content-type': 'application/json; charset=utf-8'},
+        body: JSON.stringify({
+          host,
+          key,
+          keyLocation: `https://${host}/${key}.txt`,
+          urlList,
+        }),
+      });
+      // 202 means the key file has not been fetched yet, which is what the
+      // first submission from a new key returns.
+      if (response.status !== 200 && response.status !== 202) {
+        const body = (await response.text()).trim();
+        console.error(`IndexNow returned ${response.status}: ${body}`);
+        console.error(
+          'Keeping the previous manifest so the next deploy retries these URLs.',
+        );
+        return;
+      }
+      console.log(
+        `Submitted ${urlList.length} URL(s), IndexNow returned ${response.status}.`,
+      );
+    }
+  }
+
+  await writeManifest(pending.manifest, dryRun);
+}
+
+const args = process.argv.slice(2);
+const command = args.find(argument => !argument.startsWith('-'));
+const dryRun = args.includes('--dry-run');
+const wantsHelp = args.includes('--help') || args.includes('-h');
+
+if (wantsHelp || command === undefined) {
+  printHelp();
+  process.exit(wantsHelp ? 0 : 1);
+}
+
+try {
+  if (command === 'prepare') {
+    await prepare(dryRun);
+  } else if (command === 'submit') {
+    await submit(dryRun);
+  } else {
+    console.error(`Unknown command "${command}".`);
+    printHelp();
+    process.exit(1);
+  }
+} catch (error) {
+  console.error(error.message ?? error);
+  process.exit(1);
+}


### PR DESCRIPTION
Closes DEV-488.

## Why

distr.sh has no IndexNow integration, so Bing only picks up new content when it
happens to recrawl. Bing's index also feeds DuckDuckGo, Copilot and ChatGPT
search, so that delay decides how quickly docs, glossary and `/compare/` pages
can be cited by AI assistants. Google does not participate in IndexNow, so this
is about pickup speed on Bing, not Google rankings.

## Answering the two questions on the ticket

**Can we fetch the last index date from their API?** No. IndexNow is write-only;
the spec defines a submission `GET` and `POST` and nothing else. Bing Webmaster
Tools has `GetUrlInfo` (`LastCrawledDate`), but that needs a separate BWT API key
and reports when Bing crawled, not what we submitted. The state has to be ours.

**Can we use the last modified timestamp in the content pieces?** Only for 54 of
137 URLs. Blog (26/26), glossary (22/22) and CRA (6/6) populate `lastUpdated`,
but all 68 Starlight docs pages have none in frontmatter, and the 13 static pages
and 5 case studies have no date field at all. Docs is the most frequently edited
part of the site, so content dates alone would silently skip what we most want
picked up.

## How

One piece of state serves both needs. Per sitemap URL the deploy records the hash
of the rendered page plus the date that hash was last seen to change:

- the hash answers "what changed" for IndexNow, with no source-file-to-URL
  mapping and no git history, and it catches added, changed and removed pages;
- the observed-change date is a real modification date, which is what Bing asks
  for in `lastmod`. It explicitly disregards dates that all sit on the current
  date, so pages start with no `lastmod` and earn one when they actually change.

Candidate URLs come from the built sitemap, so the `noindex` exclusions and the
redirect map in `astro.config.mjs` are respected without being restated.

`scripts/indexnow.mjs prepare` runs before the S3 sync (hash, diff, write
`lastmod` into the sitemap, record the changed URLs) and `submit` runs after the
sync and the CloudFront invalidation, so crawlers arriving immediately see the new
content. Details and the operational notes are in `scripts/indexnow.md`.

## Full git history in the checkout

Starlight derives each docs page's `lastUpdated` from git. At `fetch-depth: 1`
every page was stamped with the deploy commit, which misinforms readers today and
would additionally have made every deploy look like all 68 docs pages changed.
The pack is 42 MiB, so the full fetch is cheap.

## Behaviour without the secret

`INDEXNOW_KEY` is set on the repository, but the workflow does not depend on it:
the key-file step skips, `prepare` still maintains the manifest and the sitemap
`lastmod` values, and `submit` records the manifest without sending anything.

## Remaining manual step

Claim distr.sh in Bing Webmaster Tools (importable from Google Search Console).
Its IndexNow report is the only place submissions are visible, since no API
exposes submission history.

## Test plan

Verified locally against a real build (137 sitemap URLs):

- [x] All 137 URLs resolve to a built page.
- [x] First run records 137 hashes, submits nothing, leaves the sitemap untouched.
- [x] Rebuilding identical source reports 0 changed, and pages are byte-identical.
- [x] Changing only a CSS input, so every `_astro` asset hash shifts, reports 0
      changed. This is the case the hash normalization exists for, and Renovate
      would otherwise resubmit all 137 URLs weekly.
- [x] Appending a sentence to one glossary entry submits exactly that URL and
      gives exactly that URL a `lastmod`.
- [x] Deleting an entry from the manifest submits the now-missing URL and drops it.
- [x] Rerunning `prepare` over the same `dist` does not stack a second `<lastmod>`.
- [x] `xmllint` accepts both `sitemap-0.xml` and `sitemap-index.xml`, with
      `<lastmod>` following `<loc>` as the schema requires.
- [x] `pnpm run lint`, `pnpm run check` (0 errors, 0 warnings, 0 hints),
      `pnpm format` and `pnpm build` all clean.

Not exercised locally: the S3 read and write and the live POST, which need the
CI role. A read failure is logged and treated as a first run; a write failure
fails the step.

## Known limitation

The homepage is occasionally reported as changed when it was not.
`src/assets/index.ts` imports both
`screenshots/distr/distr-customer-portal-artifacts.webp` and its byte-identical
twin `…-artifacts-light.webp`; Astro emits a single file for the pair and which
name wins shifts with asset processing order. Dropping the duplicate would settle
it, but that belongs to the screenshot pipeline rather than this change.