### PR TITLE
fix: invalid SQL in artifacts query

### DIFF
--- a/internal/db/artifacts.go
+++ b/internal/db/artifacts.go
@@ -274,7 +274,7 @@ func GetVersionsForArtifact(ctx context.Context, artifactID uuid.UUID, customerO
 						FROM ArtifactVersionPart avp
 							JOIN ArtifactVersion av1 ON av1.manifest_blob_digest = avp.artifact_blob_digest
 						WHERE avp.artifact_version_id = av.id
-					)
+					) AS referrer_types
 				) AS referrer_artifact_types
 			FROM ArtifactVersion av
 			LEFT JOIN LATERAL (


### PR DESCRIPTION
Add the missing alias to the derived table in GetVersionsForArtifact. PostgreSQL rejects the query without it, causing artifact detail requests to return HTTP 500.

The specific error message:

```
failed to get artifact versions: ERROR: subquery in FROM must have an alias (SQLSTATE 42601)
```

<details>
<summary>Full stack trace:</summary>

```
{"level":"error","ts":"2026-09-04T03:43:47.240Z","caller":"handlers/artifacts.go:381","msg":"failed to get artifact","requestId":"cdd42762f306/eE1F3zs0xT-000881","error":"failed to get artifact versions: ERROR: subquery in FROM must have an alias (SQLSTATE 42601)","stacktrace":"github.com/distr-sh/distr/internal/handlers.artifactMiddleware.func1\n\t/home/runner/work/distr/distr/internal/handlers/artifacts.go:381\nnet/http.HandlerFunc.ServeHTTP\n\t/opt/hostedtoolcache/go/1.27.1/x64/src/net/http/server.go:2338\ngithub.com/go-chi/chi/v5.(*ChainHandler).ServeHTTP\n\t/home/runner/go/pkg/mod/github.com/go-chi/chi/v5@v5.3.2/chain.go:31\ngithub.com/go-chi/chi/v5.(*Mux).routeHTTP\n\t/home/runner/go/pkg/mod/github.com/go-chi/chi/v5@v5.3.2/mux.go:483\nnet/http.HandlerFunc.ServeHTTP\n\t/opt/hostedtoolcache/go/1.27.1/x64/src/net/http/server.go:2338\ngithub.com/distr-sh/distr/internal/authn.(*Authentication[...]).ValidatorMiddleware.func1.1\n\t/home/runner/work/distr/distr/internal/authn/authentication.go:74\nnet/http.HandlerFunc.ServeHTTP\n\t/opt/hostedtoolcache/go/1.27.1/x64/src/net/http/server.go:2338\ngithub.com/go-chi/chi/v5.(*Mux).ServeHTTP\n\t/home/runner/go/pkg/mod/github.com/go-chi/chi/v5@v5.3.2/mux.go:73\ngithub.com/go-chi/chi/v5.(*Mux).Mount.func1\n\t/home/runner/go/pkg/mod/github.com/go-chi/chi/v5@v5.3.2/mux.go:327\nnet/http.HandlerFunc.ServeHTTP\n\t/opt/hostedtoolcache/go/1.27.1/x64/src/net/http/server.go:2338\ngithub.com/go-chi/httprate.(*RateLimiter).Handler.func1\n\t/home/runner/go/pkg/mod/github.com/go-chi/httprate@v0.16.0/limiter.go:154\nnet/http.HandlerFunc.ServeHTTP\n\t/opt/hostedtoolcache/go/1.27.1/x64/src/net/http/server.go:2338\ngithub.com/go-chi/httprate.(*RateLimiter).Handler.func1\n\t/home/runner/go/pkg/mod/github.com/go-chi/httprate@v0.16.0/limiter.go:154\nnet/http.HandlerFunc.ServeHTTP\n\t/opt/hostedtoolcache/go/1.27.1/x64/src/net/http/server.go:2338\ngithub.com/go-chi/httprate.(*RateLimiter).Handler.func1\n\t/home/runner/go/pkg/mod/github.com/go-chi/httprate@v0.16.0/limiter.go:154\nnet/http.HandlerFunc.ServeHTTP\n\t/opt/hostedtoolcache/go/1.27.1/x64/src/net/http/server.go:2338\ngithub.com/distr-sh/distr/internal/middleware.RequireEmailVerified.func1\n\t/home/runner/work/distr/distr/internal/middleware/middleware.go:323\nnet/http.HandlerFunc.ServeHTTP\n\t/opt/hostedtoolcache/go/1.27.1/x64/src/net/http/server.go:2338\ngithub.com/distr-sh/distr/internal/middleware.SetSentryUserFromUserAuth.func1\n\t/home/runner/work/distr/distr/internal/middleware/middleware.go:217\nnet/http.HandlerFunc.ServeHTTP\n\t/opt/hostedtoolcache/go/1.27.1/x64/src/net/http/server.go:2338\ngithub.com/distr-sh/distr/internal/authn.(*Authentication[...]).Middleware.func1\n\t/home/runner/work/distr/distr/internal/authn/authentication.go:59\nnet/http.HandlerFunc.ServeHTTP\n\t/opt/hostedtoolcache/go/1.27.1/x64/src/net/http/server.go:2338\ngithub.com/go-chi/chi/v5/middleware.RequestSize.func1.1\n\t/home/runner/go/pkg/mod/github.com/go-chi/chi/v5@v5.3.2/middleware/request_size.go:13\nnet/http.HandlerFunc.ServeHTTP\n\t/opt/hostedtoolcache/go/1.27.1/x64/src/net/http/server.go:2338\ngithub.com/distr-sh/distr/internal/middleware.SetRequestPattern.1\n\t/home/runner/work/distr/distr/internal/middleware/middleware.go:409\nnet/http.HandlerFunc.ServeHTTP\n\t/opt/hostedtoolcache/go/1.27.1/x64/src/net/http/server.go:2338\ngo.opentelemetry.io/contrib/instrumentation/net/http/otelhttp.(*middleware).serveHTTP\n\t/home/runner/go/pkg/mod/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.71.0/handler.go:185\ngo.opentelemetry.io/contrib/instrumentation/net/http/otelhttp.NewMiddleware.func2.1\n\t/home/runner/go/pkg/mod/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.71.0/handler.go:67\nnet/http.HandlerFunc.ServeHTTP\n\t/opt/hostedtoolcache/go/1.27.1/x64/src/net/http/server.go:2338\ngithub.com/go-chi/chi/v5.(*ChainHandler).ServeHTTP\n\t/home/runner/go/pkg/mod/github.com/go-chi/chi/v5@v5.3.2/chain.go:31\ngithub.com/go-chi/chi/v5.(*Mux).routeHTTP\n\t/home/runner/go/pkg/mod/github.com/go-chi/chi/v5@v5.3.2/mux.go:483\nnet/http.HandlerFunc.ServeHTTP\n\t/opt/hostedtoolcache/go/1.27.1/x64/src/net/http/server.go:2338\ngithub.com/go-chi/chi/v5.(*Mux).ServeHTTP\n\t/home/runner/go/pkg/mod/github.com/go-chi/chi/v5@v5.3.2/mux.go:73\ngithub.com/go-chi/chi/v5.(*Mux).Mount.func1\n\t/home/runner/go/pkg/mod/github.com/go-chi/chi/v5@v5.3.2/mux.go:327\nnet/http.HandlerFunc.ServeHTTP\n\t/opt/hostedtoolcache/go/1.27.1/x64/src/net/http/server.go:2338\ngithub.com/go-chi/chi/v5.(*Mux).routeHTTP\n\t/home/runner/go/pkg/mod/github.com/go-chi/chi/v5@v5.3.2/mux.go:483\nnet/http.HandlerFunc.ServeHTTP\n\t/opt/hostedtoolcache/go/1.27.1/x64/src/net/http/server.go:2338\ngithub.com/distr-sh/distr/internal/middleware.ContextInjectorMiddleware.1.1\n\t/home/runner/work/distr/distr/internal/middleware/middleware.go:56\nnet/http.HandlerFunc.ServeHTTP\n\t/opt/hostedtoolcache/go/1.27.1/x64/src/net/http/server.go:2338\ngithub.com/distr-sh/distr/internal/middleware.MaintenanceMode.func1\n\t/home/runner/work/distr/distr/internal/middleware/maintenance.go:19\nnet/http.HandlerFunc.ServeHTTP\n\t/opt/hostedtoolcache/go/1.27.1/x64/src/net/http/server.go:2338\ngithub.com/distr-sh/distr/internal/middleware.LoggingMiddleware.func1\n\t/home/runner/work/distr/distr/internal/middleware/middleware.go:92\nnet/http.HandlerFunc.ServeHTTP\n\t/opt/hostedtoolcache/go/1.27.1/x64/src/net/http/server.go:2338\ngithub.com/distr-sh/distr/internal/middleware.LoggerCtxMiddleware.1.1\n\t/home/runner/work/distr/distr/internal/middleware/middleware.go:83\nnet/http.HandlerFunc.ServeHTTP\n\t/opt/hostedtoolcache/go/1.27.1/x64/src/net/http/server.go:2338\ngithub.com/getsentry/sentry-go/http.(*Handler).handle.func1\n\t/home/runner/go/pkg/mod/github.com/getsentry/sentry-go@v0.49.0/http/sentryhttp.go:130\nnet/http.HandlerFunc.ServeHTTP\n\t/opt/hostedtoolcache/go/1.27.1/x64/src/net/http/server.go:2338\ngithub.com/go-chi/chi/v5/middleware.ClientIPFromXFF.func1.1\n\t/home/runner/go/pkg/mod/github.com/go-chi/chi/v5@v5.3.2/middleware/client_ip.go:114\nnet/http.HandlerFunc.ServeHTTP\n\t/opt/hostedtoolcache/go/1.27.1/x64/src/net/http/server.go:2338\ngithub.com/go-chi/chi/v5/middleware.ClientIPFromRemoteAddr.func1\n\t/home/runner/go/pkg/mod/github.com/go-chi/chi/v5@v5.3.2/middleware/client_ip.go:196\nnet/http.HandlerFunc.ServeHTTP\n\t/opt/hostedtoolcache/go/1.27.1/x64/src/net/http/server.go:2338\ngithub.com/go-chi/chi/v5/middleware.RequestID.func1\n\t/home/runner/go/pkg/mod/github.com/go-chi/chi/v5@v5.3.2/middleware/request_id.go:76\nnet/http.HandlerFunc.ServeHTTP\n\t/opt/hostedtoolcache/go/1.27.1/x64/src/net/http/server.go:2338\ngithub.com/go-chi/chi/v5.(*Mux).ServeHTTP\n\t/home/runner/go/pkg/mod/github.com/go-chi/chi/v5@v5.3.2/mux.go:73\ngithub.com/go-chi/chi/v5.(*Mux).Mount.func1\n\t/home/runner/go/pkg/mod/github.com/go-chi/chi/v5@v5.3.2/mux.go:327\nnet/http.HandlerFunc.ServeHTTP\n\t/opt/hostedtoolcache/go/1.27.1/x64/src/net/http/server.go:2338\ngithub.com/go-chi/chi/v5.(*Mux).routeHTTP\n\t/home/runner/go/pkg/mod/github.com/go-chi/chi/v5@v5.3.2/mux.go:483\nnet/http.HandlerFunc.ServeHTTP\n\t/opt/hostedtoolcache/go/1.27.1/x64/src/net/http/server.go:2338\ngithub.com/go-chi/chi/v5/middleware.Recoverer.func1\n\t/home/runner/go/pkg/mod/github.com/go-chi/chi/v5@v5.3.2/middleware/recoverer.go:45\nnet/http.HandlerFunc.ServeHTTP\n\t/opt/hostedtoolcache/go/1.27.1/x64/src/net/http/server.go:2338\ngithub.com/go-chi/chi/v5.(*Mux).ServeHTTP\n\t/home/runner/go/pkg/mod/github.com/go-chi/chi/v5@v5.3.2/mux.go:90\nnet/http.serverHandler.ServeHTTP\n\t/opt/hostedtoolcache/go/1.27.1/x64/src/net/http/server.go:3413\nnet/http.(*conn).serve\n\t/opt/hostedtoolcache/go/1.27.1/x64/src/net/http/server.go:2137"}
```
</details>