### PR TITLE
fix: don't use incompatible method when uploading large artifact to GCS

### DIFF
--- a/internal/registry/blob/s3/handler.go
+++ b/internal/registry/blob/s3/handler.go
@@ -30,6 +30,7 @@ type blobHandler struct {
 	s3Client        *s3.Client
 	s3PresignClient *s3.PresignClient
 	allowRedirect   bool
+	resignForGCP    bool
 	bucket          string
 }
 
@@ -52,6 +53,7 @@ func NewBlobHandler(ctx context.Context, s3Client *s3.Client) (blob.BlobHandler,
 	h := blobHandler{
 		s3Client:      s3Client,
 		allowRedirect: s3Config.AllowRedirect,
+		resignForGCP:  s3Config.ResignForGCP,
 		bucket:        s3Config.Bucket,
 	}
 
@@ -410,15 +412,22 @@ func (handler *blobHandler) CompleteSession(ctx context.Context, repo, id string
 		}
 
 		finalKey := digest.String()
-		if err := handler.copyObject(ctx, uploadKey, finalKey); err != nil {
-			return err
-		}
+		copyErr := handler.copyObject(ctx, uploadKey, finalKey)
 
-		_, err := handler.s3Client.DeleteObject(ctx, &s3.DeleteObjectInput{
+		// The temporary object is no longer useful after the multipart upload has
+		// been completed. Clean it up even when the final copy fails; otherwise
+		// failed sessions leave non-digest-shaped chunks behind indefinitely.
+		_, deleteErr := handler.s3Client.DeleteObject(context.WithoutCancel(ctx), &s3.DeleteObjectInput{
 			Bucket: &handler.bucket,
 			Key:    &uploadKey,
 		})
-		return err
+		if deleteErr != nil {
+			internalctx.GetLogger(ctx).Warn("failed to remove completed upload chunk", zap.Error(deleteErr))
+		}
+		if copyErr != nil {
+			return copyErr
+		}
+		return deleteErr
 	}
 }
 
@@ -442,6 +451,13 @@ func (handler *blobHandler) copyObject(ctx context.Context, srcKey, dstKey strin
 			CopySource: &copySource,
 		})
 		return err
+	}
+
+	// GCS implements the S3 multipart upload API, but not multipart copy
+	// (UploadPartCopy/x-amz-copy-source-range). Stream each source range through
+	// the registry and upload it as a normal multipart part instead.
+	if handler.resignForGCP {
+		return handler.copyObjectViaUpload(ctx, srcKey, dstKey, objectSize)
 	}
 
 	upload, err := handler.s3Client.CreateMultipartUpload(ctx, &s3.CreateMultipartUploadInput{
@@ -483,6 +499,77 @@ func (handler *blobHandler) copyObject(ctx context.Context, srcKey, dstKey strin
 			return err
 		}
 		completedParts[i] = s3types.CompletedPart{PartNumber: &partNumber, ETag: result.CopyPartResult.ETag}
+	}
+
+	if _, err = handler.s3Client.CompleteMultipartUpload(ctx, &s3.CompleteMultipartUploadInput{
+		Bucket:          &handler.bucket,
+		Key:             &dstKey,
+		UploadId:        upload.UploadId,
+		MultipartUpload: &s3types.CompletedMultipartUpload{Parts: completedParts},
+	}); err != nil {
+		abort()
+		return err
+	}
+	return nil
+}
+
+// copyObjectViaUpload copies a large object by downloading source ranges and
+// uploading them as destination multipart parts. This is required for GCS,
+// whose S3-compatible API does not implement UploadPartCopy.
+func (handler *blobHandler) copyObjectViaUpload(ctx context.Context, srcKey, dstKey string, objectSize int64) error {
+	upload, err := handler.s3Client.CreateMultipartUpload(ctx, &s3.CreateMultipartUploadInput{
+		Bucket: &handler.bucket,
+		Key:    &dstKey,
+	})
+	if err != nil {
+		return err
+	}
+
+	abort := func() {
+		_, _ = handler.s3Client.AbortMultipartUpload(context.WithoutCancel(ctx), &s3.AbortMultipartUploadInput{
+			Bucket:   &handler.bucket,
+			Key:      &dstKey,
+			UploadId: upload.UploadId,
+		})
+	}
+
+	numParts := (objectSize + maxS3PartSize - 1) / maxS3PartSize
+	completedParts := make([]s3types.CompletedPart, numParts)
+	for i := range numParts {
+		partNumber := int32(i + 1)
+		rangeStart := i * maxS3PartSize
+		rangeEnd := min(rangeStart+maxS3PartSize, objectSize) - 1
+		objectRange := fmt.Sprintf("bytes=%d-%d", rangeStart, rangeEnd)
+
+		result, err := handler.s3Client.GetObject(ctx, &s3.GetObjectInput{
+			Bucket: &handler.bucket,
+			Key:    &srcKey,
+			Range:  &objectRange,
+		})
+		if err != nil {
+			abort()
+			return err
+		}
+
+		partSize := rangeEnd - rangeStart + 1
+		part, uploadErr := handler.s3Client.UploadPart(ctx, &s3.UploadPartInput{
+			Bucket:        &handler.bucket,
+			Key:           &dstKey,
+			UploadId:      upload.UploadId,
+			PartNumber:    &partNumber,
+			Body:          result.Body,
+			ContentLength: &partSize,
+		})
+		closeErr := result.Body.Close()
+		if uploadErr != nil {
+			abort()
+			return uploadErr
+		}
+		if closeErr != nil {
+			abort()
+			return closeErr
+		}
+		completedParts[i] = s3types.CompletedPart{PartNumber: &partNumber, ETag: part.ETag}
 	}
 
 	if _, err = handler.s3Client.CompleteMultipartUpload(ctx, &s3.CompleteMultipartUploadInput{

--- a/website/src/content/docs/docs/self-hosting/configuration.mdx
+++ b/website/src/content/docs/docs/self-hosting/configuration.mdx
@@ -120,10 +120,10 @@ See [Registry Configuration](/docs/registry/configuration/) for a feature overvi
 | `REGISTRY_S3_ACCESS_KEY_ID`                | no                  | —       | S3 access key ID (falls back to the default AWS credential chain if unset).        |
 | `REGISTRY_S3_SECRET_ACCESS_KEY`            | no                  | —       | S3 secret access key.                                                              |
 | `REGISTRY_S3_USE_PATH_STYLE`               | no                  | `false` | Use path-style bucket addressing (required by most non-AWS S3 implementations).    |
-| `REGISTRY_S3_ALLOW_REDIRECT`               | no                  | `true`  | Allow redirecting blob downloads directly to S3.                                   |
+| `REGISTRY_S3_ALLOW_REDIRECT`               | no                  | `true`  | Allow redirecting blob downloads directly to S3 (set `false` for GCS).              |
 | `REGISTRY_S3_REQUEST_CHECKSUM_CALCULATION` | no                  | `false` | Only calculate request checksums when required (compatibility with some backends). |
 | `REGISTRY_S3_RESPONSE_CHECKSUM_VALIDATION` | no                  | `false` | Only validate response checksums when required.                                    |
-| `REGISTRY_RESIGN_FOR_GCP`                  | no                  | `false` | Re-sign requests for Google Cloud Storage compatibility.                           |
+| `REGISTRY_RESIGN_FOR_GCP`                  | no                  | `false` | Re-sign requests and use GCS-safe large-blob finalization.                          |
 | `REGISTRY_SCRATCH_DIR`                     | no                  | —       | Directory used for temporary files during uploads.                                 |
 | `ARTIFACT_TAGS_DEFAULT_LIMIT_PER_ORG`      | no                  | `0`     | Default maximum number of artifact tags per organization. `0` means unlimited.     |
 | `REGISTRY_UPSTREAM_SYNC_CRON`              | no                  | —       | Cron schedule for syncing tags from upstream registries (pull-through cache).      |


### PR DESCRIPTION
Before: when uploading an image >5gb when using a GCS bucket, we get the following error:

```
PUT /v2/[redacted]/blobs/uploads/[sha]?digest=[digest] 500 INTERNAL_SERVER_ERROR operation error S3: UploadPartCopy, https response error StatusCode: 400, RequestID: , HostID: , api error NotImplemented: A header or query you provided requested a function that is not implemented
```

After: the same operation should work