### PR TITLE
build: reorganize mise tasks

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -149,26 +149,22 @@ description = 'Format hub and agents, without the website'
 [tasks.format]
 run = { tasks = ["format:app", "format:website"] }
 
-[tasks."run:hub:serve"]
-run = 'go run -ldflags="{{vars.ldflags}}" ./cmd/hub/ serve'
-description = 'Only starts the hub, it will not serve the frontend on that port. Protip: "mise watch run:hub:serve -r"'
-depends = ["go-tidy"]
-sources = ["api/**/*.go", "cmd/**/*.go", "internal/**/*.go"]
-
-
-[tasks."run:all:serve"]
-alias = "serve"
-run = 'go run -ldflags="{{vars.ldflags}}" ./cmd/hub/ serve'
-description = 'Builds the frontend and starts the hub server incl. serving the frontend. Protip: auto-reload with "mise watch serve -r"'
+[tasks.distr]
+run = 'go run -ldflags="{{vars.ldflags}}" ./cmd/hub/'
+description = """
+Run the hub with arbitrary arguments: "mise run distr arg1 arg2...".
+Try "mise run distr help" to explore the available commands.
+Protip: "mise watch -r distr serve" to auto-reload on code changes.
+"""
 depends = ["go-tidy", "build:frontend:dev"]
+# sources are what "mise watch" reacts to. The empty outputs keep mise from
+# skipping the task as up-to-date when they have not changed since the last run.
 sources = ["api/**/*.go", "cmd/**/*.go", "internal/**/*.go"]
+outputs = []
 
-[tasks."run:hub:db-migrate"]
-run = 'go run -ldflags="{{vars.ldflags}}" ./cmd/hub/ migrate'
-description = 'Migrate the database to the latest schema version. Protip: `mise run:hub:db-migrate -- --to xx` to migrate to a specific version'
-
-[tasks."run:hub:db-purge"]
-run = 'go run -ldflags="{{vars.ldflags}}" ./cmd/hub/ migrate --down'
+[tasks.serve]
+run = {tasks = ["distr serve"]}
+description = "Shorthand for 'mise run distr serve'"
 
 [tasks."run:agent:docker"]
 run = 'go run -ldflags="{{vars.ldflags}}" ./cmd/agent/docker/ run'

--- a/mise.toml
+++ b/mise.toml
@@ -153,6 +153,10 @@ run = { tasks = ["format:app", "format:website"] }
 run = 'go run -ldflags="{{vars.ldflags}}" ./cmd/hub/'
 description = """
 Run the hub with arbitrary arguments: "mise run distr arg1 arg2...".
+Examples:
+  - "mise run distr serve"
+  - "mise run distr migrate --to ..."
+  - "mise run distr maintenance encrypt-database"
 Try "mise run distr help" to explore the available commands.
 Protip: "mise watch -r distr serve" to auto-reload on code changes.
 """


### PR DESCRIPTION
As we add more and more CLI commands to the distr binary, it is becoming cumbersome to run some of them during development. So, I reorganized the mise file by adding a "generic" `distr` task that can be run with any argument.

Existing tasks were removed in favor of this:
* `mise run run:hub:db-migrate` --> `mise run distr migrate`
* `mise run run:hub:db-purge` --> `mise run distr migrate --down`
* `mise watch -r run:hub:serve` --> `mise watch -r distr serve`

All tasks now depend on the frontend build, as we now have working caching for that. So it is only run when it is actually needed.

The `serve` task is retained for convenience :slightly_smiling_face: 